### PR TITLE
GitHub Actions for publishing Docker Containers to GitHub CR (DEVWF-T007)

### DIFF
--- a/.github/workflows/fabrikam-api.yml
+++ b/.github/workflows/fabrikam-api.yml
@@ -1,4 +1,4 @@
-name: Fabrikam Web Build
+name: Fabrikam API Build
 
 on:
   push:
@@ -6,9 +6,8 @@ on:
     branches:
       - main
     paths:
-      - 'content-web/**'
-      - '.github/workflows/fabrikam-web.yml'
-      
+      - 'content-api/**'
+      - '.github/workflows/fabrikam-api.yml'      
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -19,7 +18,7 @@ on:
 
 env:
   # TODO: Change variable to your image's name.
-  IMAGE_NAME: fabrikam-web
+  IMAGE_NAME: fabrikam-api
 
 jobs:
   # Push image to GitHub Packages.
@@ -32,14 +31,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        working-directory: content-web
+        working-directory: content-api
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
-        working-directory: content-web
+        working-directory: content-api
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 

--- a/.github/workflows/fabrikam-init.yml
+++ b/.github/workflows/fabrikam-init.yml
@@ -1,4 +1,4 @@
-name: Fabrikam Web Build
+name: Fabrikam Init Build
 
 on:
   push:
@@ -6,9 +6,8 @@ on:
     branches:
       - main
     paths:
-      - 'content-web/**'
-      - '.github/workflows/fabrikam-web.yml'
-      
+      - 'content-init/**'
+      - '.github/workflows/fabrikam-init.yml'
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -19,7 +18,7 @@ on:
 
 env:
   # TODO: Change variable to your image's name.
-  IMAGE_NAME: fabrikam-web
+  IMAGE_NAME: fabrikam-init
 
 jobs:
   # Push image to GitHub Packages.
@@ -32,14 +31,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        working-directory: content-web
+        working-directory: content-init
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
-        working-directory: content-web
+        working-directory: content-init
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 


### PR DESCRIPTION

# Instructions to Fix the exercise

Added these 3 GitHub Actions. They trigger automatically when a new commit happens in the files associated to the build.

> One thing to Do.
>
> Create a new GitHub Secret called `CR_PAT` that contains your Personal Access Token with write:packages and read:packages permissions

Linked to [AB#19](https://dev.azure.com/jimblizzarddemos/9f8d761f-6363-4092-a0d6-6a1a377d4080/_workitems/edit/19)